### PR TITLE
Merge upstream dev/3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ and you can configure it from there.
 
 Alternatively, you can get the proxy JAR from the [downloads](https://papermc.io/downloads/velocity)
 page.
+
+# Localisation
+
+Translations are handled using [Crowdin](https://papermc-io.crowdin.com/velocity).
+If you want to translate a language not available on Crowdin,
+you might want to ask in the [Discord](https://discord.gg/papermc) about it.

--- a/api/src/main/java/com/velocitypowered/api/event/command/package-info.java
+++ b/api/src/main/java/com/velocitypowered/api/event/command/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+/**
+ * Provides events for handling command execution.
+ */
+package com.velocitypowered.api.event.command;

--- a/api/src/main/java/com/velocitypowered/api/event/player/configuration/package-info.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/configuration/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+/**
+ * Provides events for handling the player configuration phase.
+ */
+package com.velocitypowered.api.event.player.configuration;

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/package-info.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+/**
+ * Provides events for handling registration of servers on the proxy.
+ */
+package com.velocitypowered.api.event.proxy.server;

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -95,7 +95,7 @@ public enum ProtocolVersion implements Ordered<ProtocolVersion> {
   MINECRAFT_1_21_7(772, "1.21.7", "1.21.8"),
   MINECRAFT_1_21_9(773, "1.21.9", "1.21.10"),
   MINECRAFT_1_21_11(774, "1.21.11"),
-  MINECRAFT_26_1(775, "26.1", "26.1.1");
+  MINECRAFT_26_1(775, "26.1", "26.1.1", "26.1.2");
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -95,7 +95,7 @@ public enum ProtocolVersion implements Ordered<ProtocolVersion> {
   MINECRAFT_1_21_7(772, "1.21.7", "1.21.8"),
   MINECRAFT_1_21_9(773, "1.21.9", "1.21.10"),
   MINECRAFT_1_21_11(774, "1.21.11"),
-  MINECRAFT_26_1(775, "26.1");
+  MINECRAFT_26_1(775, "26.1", "26.1.1");
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -95,7 +95,8 @@ public enum ProtocolVersion implements Ordered<ProtocolVersion> {
   MINECRAFT_1_21_7(772, "1.21.7", "1.21.8"),
   MINECRAFT_1_21_9(773, "1.21.9", "1.21.10"),
   MINECRAFT_1_21_11(774, "1.21.11"),
-  MINECRAFT_26_1(775, "26.1", "26.1.1", "26.1.2");
+  MINECRAFT_26_1(775, "26.1", "26.1.1", "26.1.2"),
+  MINECRAFT_26_2(776, "26.2");
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -197,7 +197,7 @@ public interface Player extends
    *
    * @param reason component with the reason
    */
-  void disconnect(Component reason);
+  void disconnect(@NotNull Component reason);
 
   /**
    * Sends chat input onto the players current server as if they typed it into the client chat box.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ configurate3 = "3.7.3"
 configurate4 = "4.2.0"
 flare = "2.0.1"
 log4j = "2.25.3"
-netty = "4.2.10.Final"
+netty = "4.2.15.Final"
 
 [plugins]
 fill = "io.papermc.fill.gradle:1.0.10"

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -165,6 +165,8 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
 
   private final Map<UUID, ConnectedPlayer> connectionsByUuid = new ConcurrentHashMap<>();
   private final Map<String, ConnectedPlayer> connectionsByName = new ConcurrentHashMap<>();
+  private final Object sessionIdLock = new Object();
+  private volatile @Nullable UUID sessionId;
   private final VelocityConsole console;
   private @MonotonicNonNull Ratelimiter<InetAddress> ipAttemptLimiter;
   private @MonotonicNonNull Ratelimiter<UUID> commandRateLimiter;
@@ -743,6 +745,36 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     connectionsByName.remove(connection.getUsername().toLowerCase(Locale.US), connection);
     connectionsByUuid.remove(connection.getUniqueId(), connection);
     connection.disconnected();
+
+    if (this.sessionId != null && connectionsByUuid.isEmpty()) {
+      synchronized (this.sessionIdLock) {
+        if (connectionsByUuid.isEmpty()) {
+          this.sessionId = null;
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns the metrics session ID for this proxy, generating one if none is currently active. The
+   * ID is shared by every player connected during a populated period and is regenerated once the
+   * proxy empties.
+   *
+   * @return the current session ID
+   */
+  public UUID getSessionId() {
+    UUID uuid = this.sessionId;
+    if (uuid != null) {
+      return uuid;
+    }
+    synchronized (this.sessionIdLock) {
+      uuid = this.sessionId;
+      if (uuid == null) {
+        uuid = UUID.randomUUID();
+        this.sessionId = uuid;
+      }
+      return uuid;
+    }
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -94,6 +94,8 @@ public class VelocityConfiguration implements ProxyConfig {
   private @Nullable Favicon favicon;
   @Expose
   private boolean forceKeyAuthentication = true; // Added in 1.19
+  @Expose
+  private PacketLimiterConfig packetLimiterConfig = PacketLimiterConfig.DEFAULT;
 
   private VelocityConfiguration(Servers servers, ForcedHosts forcedHosts, Advanced advanced,
       Query query, Metrics metrics) {
@@ -110,7 +112,7 @@ public class VelocityConfiguration implements ProxyConfig {
       boolean onlineModeKickExistingPlayers, PingPassthroughMode pingPassthrough,
       boolean samplePlayersInPing, boolean enablePlayerAddressLogging, Servers servers,
       ForcedHosts forcedHosts, Advanced advanced, Query query, Metrics metrics,
-      boolean forceKeyAuthentication) {
+      boolean forceKeyAuthentication, PacketLimiterConfig packetLimiterConfig) {
     this.bind = bind;
     this.motd = motd;
     this.showMaxPlayers = showMaxPlayers;
@@ -129,6 +131,7 @@ public class VelocityConfiguration implements ProxyConfig {
     this.query = query;
     this.metrics = metrics;
     this.forceKeyAuthentication = forceKeyAuthentication;
+    this.packetLimiterConfig = packetLimiterConfig;
   }
 
   /**
@@ -447,6 +450,10 @@ public class VelocityConfiguration implements ProxyConfig {
     return advanced.isEnableReusePort();
   }
 
+  public PacketLimiterConfig getPacketLimiterConfig() {
+    return packetLimiterConfig;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -464,6 +471,7 @@ public class VelocityConfiguration implements ProxyConfig {
         .add("favicon", favicon)
         .add("enablePlayerAddressLogging", enablePlayerAddressLogging)
         .add("forceKeyAuthentication", forceKeyAuthentication)
+        .add("packetLimiterConfig", packetLimiterConfig)
         .toString();
   }
 
@@ -560,6 +568,7 @@ public class VelocityConfiguration implements ProxyConfig {
       final boolean kickExisting = config.getOrElse("kick-existing-players", false);
       final boolean enablePlayerAddressLogging = config.getOrElse(
               "enable-player-address-logging", true);
+      final PacketLimiterConfig packetLimiterConfig = PacketLimiterConfig.fromConfig(config.get("packet-limiter"));
 
       // Throw an exception if the forwarding-secret file is empty and the proxy is using a
       // forwarding mode that requires it.
@@ -587,7 +596,8 @@ public class VelocityConfiguration implements ProxyConfig {
               new Advanced(advancedConfig),
               new Query(queryConfig),
               new Metrics(metricsConfig),
-              forceKeyAuthentication
+              forceKeyAuthentication,
+              packetLimiterConfig
       );
     }
   }
@@ -988,6 +998,35 @@ public class VelocityConfiguration implements ProxyConfig {
 
     public boolean isEnabled() {
       return enabled;
+    }
+  }
+
+  /**
+   * Configuration for packet limiting.
+   *
+   * @param interval the interval in seconds to measure packets over
+   * @param pps      the maximum number of packets per second allowed
+   * @param bytes    the maximum number of bytes per second allowed
+   */
+  public record PacketLimiterConfig(int interval, int pps, int bytes) {
+    public static PacketLimiterConfig DEFAULT = new PacketLimiterConfig(7, 500, -1);
+
+    /**
+     * returns a PacketLimiterConfig from a config section, or the default if the section is null.
+     *
+     * @param config the configuration object to parse
+     * @return the packet limiter config, or the default if {@code config} is null
+     */
+    public static PacketLimiterConfig fromConfig(CommentedConfig config) {
+      if (config != null) {
+        return new PacketLimiterConfig(
+            config.getIntOrElse("interval", DEFAULT.interval()),
+            config.getIntOrElse("packets-per-second", DEFAULT.pps()),
+            config.getIntOrElse("bytes-per-second", DEFAULT.bytes())
+        );
+      } else {
+        return DEFAULT;
+      }
     }
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -31,6 +31,7 @@ import com.velocitypowered.proxy.config.migration.ForwardingMigration;
 import com.velocitypowered.proxy.config.migration.KeyAuthenticationMigration;
 import com.velocitypowered.proxy.config.migration.MiniMessageTranslationsMigration;
 import com.velocitypowered.proxy.config.migration.MotdMigration;
+import com.velocitypowered.proxy.config.migration.PacketLimiterMigration;
 import com.velocitypowered.proxy.config.migration.TransferIntegrationMigration;
 import com.velocitypowered.proxy.util.AddressUtil;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -511,7 +512,8 @@ public class VelocityConfiguration implements ProxyConfig {
           new KeyAuthenticationMigration(),
           new MotdMigration(),
           new MiniMessageTranslationsMigration(),
-          new TransferIntegrationMigration()
+          new TransferIntegrationMigration(),
+          new PacketLimiterMigration()
       };
 
       for (final ConfigurationMigration migration : migrations) {
@@ -1004,12 +1006,13 @@ public class VelocityConfiguration implements ProxyConfig {
   /**
    * Configuration for packet limiting.
    *
-   * @param interval the interval in seconds to measure packets over
-   * @param pps      the maximum number of packets per second allowed
-   * @param bytes    the maximum number of bytes per second allowed
+   * @param interval                the interval in seconds to measure packets over
+   * @param pps                     the maximum number of packets per second allowed
+   * @param bytes                   the maximum number of bytes per second allowed
+   * @param bytesAfterDecompression the maximum number of decompressed bytes per second allowed
    */
-  public record PacketLimiterConfig(int interval, int pps, int bytes) {
-    public static PacketLimiterConfig DEFAULT = new PacketLimiterConfig(7, 500, -1);
+  public record PacketLimiterConfig(int interval, int pps, int bytes, int bytesAfterDecompression) {
+    public static PacketLimiterConfig DEFAULT = new PacketLimiterConfig(7, -1, -1, 5242880);
 
     /**
      * returns a PacketLimiterConfig from a config section, or the default if the section is null.
@@ -1022,7 +1025,8 @@ public class VelocityConfiguration implements ProxyConfig {
         return new PacketLimiterConfig(
             config.getIntOrElse("interval", DEFAULT.interval()),
             config.getIntOrElse("packets-per-second", DEFAULT.pps()),
-            config.getIntOrElse("bytes-per-second", DEFAULT.bytes())
+            config.getIntOrElse("bytes-per-second", DEFAULT.bytes()),
+            config.getIntOrElse("decompressed-bytes-per-second", DEFAULT.bytesAfterDecompression())
         );
       } else {
         return DEFAULT;

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/migration/ConfigurationMigration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/migration/ConfigurationMigration.java
@@ -29,7 +29,8 @@ public sealed interface ConfigurationMigration
                 KeyAuthenticationMigration,
                 MotdMigration,
                 MiniMessageTranslationsMigration,
-                TransferIntegrationMigration {
+                TransferIntegrationMigration,
+                PacketLimiterMigration {
   boolean shouldMigrate(CommentedFileConfig config);
 
   void migrate(CommentedFileConfig config, Logger logger) throws IOException;

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/migration/PacketLimiterMigration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/migration/PacketLimiterMigration.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.config.migration;
+
+import static com.velocitypowered.proxy.config.VelocityConfiguration.PacketLimiterConfig.DEFAULT;
+
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Configuration migration for the new [packet-limiter] section.
+ * Config version 2.7 may contain this section with only the `interval`, `packets-per-second`
+ * and `bytes-per-second` attributes. Config version 2.8 enforces these exist, adds the new
+ * `decompressed-bytes-per-second` attribute, adjusts the new default, and adds comments.
+ */
+public final class PacketLimiterMigration implements ConfigurationMigration {
+
+  @Override
+  public boolean shouldMigrate(CommentedFileConfig config) {
+    return configVersion(config) < 2.8;
+  }
+
+  @Override
+  public void migrate(CommentedFileConfig config, Logger logger) {
+    config.set("packet-limiter.interval", DEFAULT.interval());
+    config.set("packet-limiter.packets-per-second", DEFAULT.pps());
+    config.set("packet-limiter.bytes-per-second", DEFAULT.bytes());
+    config.set("packet-limiter.decompressed-bytes-per-second", DEFAULT.bytesAfterDecompression());
+
+    config.setComment("packet-limiter.interval", """
+        Size of the moving time window in seconds used to calculate average rates.
+        A larger window tolerates short bursts while still enforcing the configured limits over time.""");
+
+    config.setComment("packet-limiter.packets-per-second", """
+        Maximum average number of packets per second a client may send. -1 disables this check.""");
+
+    config.setComment("packet-limiter.bytes-per-second", """
+        Maximum average number of compressed (on-wire) bytes per second a client may send. -1 disables this check.""");
+
+    config.setComment("packet-limiter.decompressed-bytes-per-second", """
+        Maximum average number of decompressed bytes per second a client may send.
+        Protects against compression bomb attacks where small packets expand to excessive sizes after decompression.
+        -1 disables this check.""");
+
+    config.set("config-version", "2.8");
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -38,7 +38,6 @@ import com.velocitypowered.proxy.connection.client.InitialLoginSessionHandler;
 import com.velocitypowered.proxy.connection.client.StatusSessionHandler;
 import com.velocitypowered.proxy.network.Connections;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
-import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.VelocityConnectionEvent;
 import com.velocitypowered.proxy.protocol.netty.MinecraftCipherDecoder;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -38,6 +38,7 @@ import com.velocitypowered.proxy.connection.client.InitialLoginSessionHandler;
 import com.velocitypowered.proxy.connection.client.StatusSessionHandler;
 import com.velocitypowered.proxy.network.Connections;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.VelocityConnectionEvent;
 import com.velocitypowered.proxy.protocol.netty.MinecraftCipherDecoder;
@@ -544,9 +545,10 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
       } else {
         int level = server.getConfiguration().getCompressionLevel();
         VelocityCompressor compressor = Natives.compress.get().create(level);
+        final MinecraftDecoder minecraftDecoder = (MinecraftDecoder) channel.pipeline().get(MINECRAFT_DECODER);
 
         encoder = new MinecraftCompressorAndLengthEncoder(threshold, compressor);
-        decoder = new MinecraftCompressDecoder(threshold, compressor);
+        decoder = new MinecraftCompressDecoder(threshold, compressor, minecraftDecoder.getDirection());
 
         channel.pipeline().remove(FRAME_ENCODER);
         channel.pipeline().addBefore(MINECRAFT_DECODER, COMPRESSION_DECODER, decoder);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -67,7 +67,7 @@ import io.netty.util.ReferenceCountUtil;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.security.GeneralSecurityException;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -109,7 +109,7 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
     this.server = server;
     this.state = StateRegistry.HANDSHAKE;
 
-    this.sessionHandlers = new HashMap<>();
+    this.sessionHandlers = new EnumMap<>(StateRegistry.class);
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -33,6 +33,7 @@ import com.velocitypowered.natives.encryption.VelocityCipher;
 import com.velocitypowered.natives.encryption.VelocityCipherFactory;
 import com.velocitypowered.natives.util.Natives;
 import com.velocitypowered.proxy.VelocityServer;
+import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.connection.client.HandshakeSessionHandler;
 import com.velocitypowered.proxy.connection.client.InitialLoginSessionHandler;
 import com.velocitypowered.proxy.connection.client.StatusSessionHandler;
@@ -368,6 +369,7 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
   public void setState(StateRegistry state) {
     ensureInEventLoop();
 
+    final StateRegistry previousState = this.state;
     this.state = state;
     final MinecraftVarintFrameDecoder frameDecoder = this.channel.pipeline()
         .get(MinecraftVarintFrameDecoder.class);
@@ -388,7 +390,13 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
 
     if (state == StateRegistry.CONFIG) {
       // Activate the play packet queue
-      addPlayPacketQueueHandler();
+      if (previousState == StateRegistry.PLAY
+          && this.pendingConfigurationSwitch
+          && this.association instanceof ConnectedPlayer) {
+        addPlayPacketQueueOutboundHandler();
+      } else {
+        addPlayPacketQueueHandler();
+      }
     } else {
       // Remove the queue
       if (this.channel.pipeline().get(Connections.PLAY_PACKET_QUEUE_OUTBOUND) != null) {
@@ -404,13 +412,23 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
    * Adds the play packet queue handler.
    */
   public void addPlayPacketQueueHandler() {
-    if (this.channel.pipeline().get(Connections.PLAY_PACKET_QUEUE_OUTBOUND) == null) {
-      this.channel.pipeline().addAfter(Connections.MINECRAFT_ENCODER, Connections.PLAY_PACKET_QUEUE_OUTBOUND,
-           new PlayPacketQueueOutboundHandler(this.protocolVersion, channel.pipeline().get(MinecraftEncoder.class).getDirection()));
-    }
+    addPlayPacketQueueOutboundHandler();
+
     if (this.channel.pipeline().get(Connections.PLAY_PACKET_QUEUE_INBOUND) == null) {
       this.channel.pipeline().addAfter(Connections.MINECRAFT_DECODER, Connections.PLAY_PACKET_QUEUE_INBOUND,
-           new PlayPacketQueueInboundHandler(this.protocolVersion, channel.pipeline().get(MinecraftDecoder.class).getDirection()));
+           new PlayPacketQueueInboundHandler(this.protocolVersion,
+               channel.pipeline().get(MinecraftDecoder.class).getDirection()));
+    }
+  }
+
+  /**
+   * Adds only the outbound play packet queue handler.
+   */
+  public void addPlayPacketQueueOutboundHandler() {
+    if (this.channel.pipeline().get(Connections.PLAY_PACKET_QUEUE_OUTBOUND) == null) {
+      this.channel.pipeline().addAfter(Connections.MINECRAFT_ENCODER, Connections.PLAY_PACKET_QUEUE_OUTBOUND,
+           new PlayPacketQueueOutboundHandler(this.protocolVersion,
+               channel.pipeline().get(MinecraftEncoder.class).getDirection()));
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -38,7 +38,9 @@ import com.velocitypowered.proxy.connection.client.HandshakeSessionHandler;
 import com.velocitypowered.proxy.connection.client.InitialLoginSessionHandler;
 import com.velocitypowered.proxy.connection.client.StatusSessionHandler;
 import com.velocitypowered.proxy.network.Connections;
+import com.velocitypowered.proxy.network.limiter.SimpleBytesPerSecondLimiter;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.VelocityConnectionEvent;
 import com.velocitypowered.proxy.protocol.netty.MinecraftCipherDecoder;
@@ -570,6 +572,14 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
         channel.pipeline().remove(FRAME_ENCODER);
         channel.pipeline().addBefore(MINECRAFT_DECODER, COMPRESSION_DECODER, decoder);
         channel.pipeline().addBefore(MINECRAFT_ENCODER, COMPRESSION_ENCODER, encoder);
+
+        var packetLimiterConfig = server.getConfiguration().getPacketLimiterConfig();
+        if (minecraftDecoder.getDirection() == ProtocolUtils.Direction.SERVERBOUND
+            && packetLimiterConfig.interval() > 0
+            && packetLimiterConfig.bytesAfterDecompression() > 0) {
+          decoder.setPacketLimiter(new SimpleBytesPerSecondLimiter(
+              -1, packetLimiterConfig.bytesAfterDecompression(), packetLimiterConfig.interval()));
+        }
 
         channel.pipeline().fireUserEventTriggered(VelocityConnectionEvent.COMPRESSION_ENABLED);
       }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -68,6 +68,7 @@ import com.velocitypowered.proxy.protocol.packet.TransferPacket;
 import com.velocitypowered.proxy.protocol.packet.UpsertPlayerInfoPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import com.velocitypowered.proxy.protocol.packet.config.StartUpdatePacket;
+import com.velocitypowered.proxy.protocol.util.DeferredByteBufHolder;
 import com.velocitypowered.proxy.protocol.util.PluginMessageUtil;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
@@ -91,6 +92,7 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
       Boolean.getBoolean("velocity.log-server-backpressure");
   private static final int MAXIMUM_PACKETS_TO_FLUSH =
       Integer.getInteger("velocity.max-packets-per-flush", 8192);
+  private static final int LARGE_PACKET_THRESHOLD = 1024 * 128;
 
   private final VelocityServer server;
   private final VelocityServerConnection serverConn;
@@ -455,8 +457,9 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
     if (packet instanceof PluginMessagePacket pluginMessage) {
       pluginMessage.retain();
     }
+    boolean huge = packet instanceof DeferredByteBufHolder def && def.content().readableBytes() > LARGE_PACKET_THRESHOLD;
     playerConnection.delayedWrite(packet);
-    if (++packetsFlushed >= MAXIMUM_PACKETS_TO_FLUSH) {
+    if (huge || ++packetsFlushed >= MAXIMUM_PACKETS_TO_FLUSH) {
       playerConnection.flush();
       packetsFlushed = 0;
     }
@@ -464,8 +467,9 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
 
   @Override
   public void handleUnknown(ByteBuf buf) {
+    boolean huge = buf.readableBytes() > LARGE_PACKET_THRESHOLD;
     playerConnection.delayedWrite(buf.retain());
-    if (++packetsFlushed >= MAXIMUM_PACKETS_TO_FLUSH) {
+    if (huge || ++packetsFlushed >= MAXIMUM_PACKETS_TO_FLUSH) {
       playerConnection.flush();
       packetsFlushed = 0;
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -61,7 +61,6 @@ import com.velocitypowered.proxy.protocol.util.PluginMessageUtil;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
 import net.kyori.adventure.key.Key;
@@ -377,8 +376,8 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public void disconnected() {
-    resultFuture.completeExceptionally(
-        new IOException("Unexpectedly disconnected from remote server"));
+    resultFuture.complete(ConnectionRequestResults.forDisconnect(
+        ConnectionMessages.INTERNAL_SERVER_CONNECTION_ERROR, serverConn.getServer()));
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -38,7 +38,6 @@ import com.velocitypowered.proxy.protocol.packet.DisconnectPacket;
 import com.velocitypowered.proxy.protocol.packet.JoinGamePacket;
 import com.velocitypowered.proxy.protocol.packet.KeepAlivePacket;
 import com.velocitypowered.proxy.protocol.packet.PluginMessagePacket;
-import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -213,7 +212,7 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public void disconnected() {
-    resultFuture
-        .completeExceptionally(new IOException("Unexpectedly disconnected from remote server"));
+    resultFuture.complete(ConnectionRequestResults.forDisconnect(
+        ConnectionMessages.INTERNAL_SERVER_CONNECTION_ERROR, serverConn.getServer()));
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -89,7 +89,7 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(JoinGamePacket packet) {
-    MinecraftConnection smc = serverConn.ensureConnected();
+    final MinecraftConnection smc = serverConn.ensureConnected();
     final RegisteredServer previousServer = serverConn.getPreviousServer().orElse(null);
     final ConnectedPlayer player = serverConn.getPlayer();
     final VelocityServerConnection existingConnection = player.getConnectedServer();
@@ -105,6 +105,9 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
 
     // Reset Tablist header and footer to prevent desync
     player.clearPlayerListHeaderAndFooter();
+
+    // Override online mode
+    packet.setOnlineMode(player.isOnlineMode());
 
     // The goods are in hand! We got JoinGame. Let's transition completely to the new state.
     smc.setAutoReading(false);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
@@ -236,6 +236,9 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
         success.setUsername(player.getUsername());
         success.setProperties(player.getGameProfileProperties());
         success.setUuid(player.getUniqueId());
+        if (inbound.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
+          success.setSessionId(UUID.randomUUID()); // use random uuid for now
+        }
         mcConnection.write(success);
 
         loginState = State.SUCCESS_SENT;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
@@ -237,7 +237,7 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
         success.setProperties(player.getGameProfileProperties());
         success.setUuid(player.getUniqueId());
         if (inbound.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
-          success.setSessionId(UUID.randomUUID()); // use random uuid for now
+          success.setSessionId(server.getSessionId());
         }
         mcConnection.write(success);
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -270,7 +270,7 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
   public void exception(Throwable throwable) {
     player.disconnect(Component.translatable("velocity.error.player-connection-error", NamedTextColor.RED));
     if (MinecraftDecoder.DEBUG) {
-      logger.info("Exception while handling plugin message packet for {}", player, throwable);
+      logger.info("Exception while handling packet for {}", player, throwable);
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -33,6 +33,7 @@ import com.velocitypowered.proxy.connection.player.resourcepack.ResourcePackResp
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.StateRegistry;
+import com.velocitypowered.proxy.protocol.netty.MinecraftDecoder;
 import com.velocitypowered.proxy.protocol.netty.MinecraftEncoder;
 import com.velocitypowered.proxy.protocol.packet.ClientSettingsPacket;
 import com.velocitypowered.proxy.protocol.packet.KeepAlivePacket;
@@ -268,6 +269,9 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
   @Override
   public void exception(Throwable throwable) {
     player.disconnect(Component.translatable("velocity.error.player-connection-error", NamedTextColor.RED));
+    if (MinecraftDecoder.DEBUG) {
+      logger.info("Exception while handling plugin message packet for {}", player, throwable);
+    }
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -41,6 +41,7 @@ import com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeConstants;
 import com.velocitypowered.proxy.connection.player.resourcepack.ResourcePackResponseBundle;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.StateRegistry;
+import com.velocitypowered.proxy.protocol.netty.MinecraftDecoder;
 import com.velocitypowered.proxy.protocol.packet.BossBarPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientSettingsPacket;
 import com.velocitypowered.proxy.protocol.packet.JoinGamePacket;
@@ -509,6 +510,9 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
   public void exception(Throwable throwable) {
     player.disconnect(
         Component.translatable("velocity.error.player-connection-error", NamedTextColor.RED));
+    if (MinecraftDecoder.DEBUG) {
+      logger.info("Exception while handling plugin message packet for {}", player, throwable);
+    }
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -470,7 +470,11 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
     }
 
     MinecraftConnection smc = serverConnection.getConnection();
-    if (smc != null && serverConnection.getPhase().consideredComplete()) {
+    final boolean stateAllowsForward = smc != null
+        && !smc.isClosed()
+        && serverConnection.getPhase().consideredComplete()
+        && smc.getState() == StateRegistry.PLAY;
+    if (stateAllowsForward) {
       if (packet instanceof PluginMessagePacket) {
         ((PluginMessagePacket) packet).retain();
       }
@@ -487,7 +491,11 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
     }
 
     MinecraftConnection smc = serverConnection.getConnection();
-    if (smc != null && !smc.isClosed() && serverConnection.getPhase().consideredComplete()) {
+    final boolean stateAllowsForward = smc != null
+        && !smc.isClosed()
+        && serverConnection.getPhase().consideredComplete()
+        && smc.getState() == StateRegistry.PLAY;
+    if (stateAllowsForward) {
       smc.write(buf.retain());
     }
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -508,10 +508,9 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
 
   @Override
   public void exception(Throwable throwable) {
-    player.disconnect(
-        Component.translatable("velocity.error.player-connection-error", NamedTextColor.RED));
+    player.disconnect(Component.translatable("velocity.error.player-connection-error", NamedTextColor.RED));
     if (MinecraftDecoder.DEBUG) {
-      logger.info("Exception while handling plugin message packet for {}", player, throwable);
+      logger.info("Exception while handling packet for {}", player, throwable);
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -86,6 +86,8 @@ import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
@@ -102,12 +104,23 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
   private static final boolean BACKPRESSURE_LOG =
       Boolean.getBoolean("velocity.log-server-backpressure");
 
+  // Caps the per-connection queue used while the FML/login phases are not yet "complete". Without
+  // these caps, a client that never completes its handshake phase can spam plugin messages (each up
+  // to ~32 KiB serverbound) and grow the queue without bound.
+  private static final long MAX_QUEUED_LOGIN_PLUGIN_MESSAGE_BYTES =
+      Long.getLong("velocity.max-queued-login-plugin-message-bytes", 4L * 1024 * 1024);
+  private static final int MAX_QUEUED_LOGIN_PLUGIN_MESSAGES =
+      Integer.getInteger("velocity.max-queued-login-plugin-messages", 1024);
+
   private static final Logger logger = LogManager.getLogger(ClientPlaySessionHandler.class);
 
   private final ConnectedPlayer player;
   private boolean spawned = false;
   private final List<UUID> serverBossBars = new ArrayList<>();
   private final Queue<PluginMessagePacket> loginPluginMessages = new ConcurrentLinkedQueue<>();
+  private final AtomicLong loginPluginMessagesBytes = new AtomicLong();
+  private final AtomicInteger loginPluginMessagesCount = new AtomicInteger();
+  private volatile boolean loginPluginMessagesOverflowed;
   private final VelocityServer server;
   private @Nullable TabCompleteRequestPacket outstandingTabComplete;
   private final ChatHandler<? extends MinecraftPacket> chatHandler;
@@ -176,9 +189,38 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
   @Override
   public void deactivated() {
     player.discardChatQueue();
-    for (PluginMessagePacket message : loginPluginMessages) {
+    PluginMessagePacket message;
+    while ((message = loginPluginMessages.poll()) != null) {
       ReferenceCountUtil.release(message);
     }
+    loginPluginMessagesBytes.set(0);
+    loginPluginMessagesCount.set(0);
+  }
+
+  /**
+   * Adds a retained plugin message to the queue used while the FML/login phases are still in
+   * progress, enforcing the per-connection byte and count caps. Returns {@code true} if queued,
+   * {@code false} if the packet was released (and the player disconnected on overflow).
+   */
+  private boolean enqueueLoginPluginMessage(PluginMessagePacket packet) {
+    if (loginPluginMessagesOverflowed) {
+      ReferenceCountUtil.release(packet);
+      return false;
+    }
+    int packetSize = packet.content().readableBytes();
+    long newBytes = loginPluginMessagesBytes.addAndGet(packetSize);
+    int newCount = loginPluginMessagesCount.incrementAndGet();
+    if (newBytes > MAX_QUEUED_LOGIN_PLUGIN_MESSAGE_BYTES
+        || newCount > MAX_QUEUED_LOGIN_PLUGIN_MESSAGES) {
+      loginPluginMessagesOverflowed = true;
+      ReferenceCountUtil.release(packet);
+      logger.warn("Disconnecting {}: pre-join plugin-message queue exceeded its limits "
+              + "({} messages, {} bytes).", player, newCount, newBytes);
+      player.disconnect(Component.translatable("velocity.error.plugin-message-overflow"));
+      return false;
+    }
+    loginPluginMessages.add(packet);
+    return true;
   }
 
   @Override
@@ -359,7 +401,7 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
               //
               // We also need to make sure to retain these packets, so they can be flushed
               // appropriately.
-              loginPluginMessages.add(packet.retain());
+              enqueueLoginPluginMessage(packet.retain());
             } else {
               // The connection is ready, send the packet now.
               backendConn.write(packet.retain());
@@ -374,7 +416,7 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
                 if (!player.getPhase().consideredComplete() || !serverConn.getPhase()
                     .consideredComplete()) {
                   // We're still processing the connection (see above), enqueue the packet for now.
-                  loginPluginMessages.add(message.retain());
+                  enqueueLoginPluginMessage(message.retain());
                 } else {
                   backendConn.write(message);
                 }
@@ -637,6 +679,8 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
     while ((pm = loginPluginMessages.poll()) != null) {
       serverMc.delayedWrite(pm);
     }
+    loginPluginMessagesBytes.set(0);
+    loginPluginMessagesCount.set(0);
 
     // Clear any title from the previous server.
     if (player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_8)) {
@@ -869,6 +913,8 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
         while ((pm = loginPluginMessages.poll()) != null) {
           connection.write(pm);
         }
+        loginPluginMessagesBytes.set(0);
+        loginPluginMessagesCount.set(0);
       }
     }
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1349,11 +1349,17 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       final Long sentTime = serverConnection.getPendingPings().remove(packet.getRandomId());
       if (sentTime != null) {
         final MinecraftConnection smc = serverConnection.getConnection();
-        if (smc != null) {
+        final StateRegistry clientState = connection.getState();
+        final boolean stateAllowsForward = smc != null
+            && !smc.isClosed()
+            && clientState == smc.getState()
+            && (clientState == StateRegistry.CONFIG || clientState == StateRegistry.PLAY);
+        if (stateAllowsForward) {
           setPing(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - sentTime));
           smc.write(packet);
-          return true;
         }
+        // We removed this, and so this is ours
+        return true;
       }
     }
     return false;
@@ -1363,7 +1369,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
    * Switches the connection to the client into config state.
    */
   public void switchToConfigState() {
-    server.getEventManager().fire(new PlayerEnterConfigurationEvent(this, getConnectionInFlightOrConnectedServer()))
+    final VelocityServerConnection targetServer = getConnectionInFlightOrConnectedServer();
+    server.getEventManager().fire(new PlayerEnterConfigurationEvent(this, targetServer))
         .completeOnTimeout(null, 5, TimeUnit.SECONDS).thenRunAsync(() -> {
           // if the connection was closed earlier, there is a risk that the player is no longer connected
           if (!connection.getChannel().isActive()) {
@@ -1378,7 +1385,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
           connection.pendingConfigurationSwitch = true;
           connection.getChannel().pipeline().get(MinecraftEncoder.class).setState(StateRegistry.CONFIG);
           // Make sure we don't send any play packets to the player after update start
-          connection.addPlayPacketQueueHandler();
+          connection.addPlayPacketQueueOutboundHandler();
         }, connection.eventLoop()).exceptionally((ex) -> {
           logger.error("Error switching player connection to config state", ex);
           return null;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -111,6 +111,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -645,7 +646,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   }
 
   @Override
-  public void disconnect(Component reason) {
+  public void disconnect(@NotNull Component reason) {
+    Objects.requireNonNull(reason, "reason");
     if (connection.eventLoop().inEventLoop()) {
       disconnect0(reason, false);
     } else {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -45,7 +45,6 @@ import java.net.InetSocketAddress;
 import java.util.Optional;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.minimessage.translation.Argument;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -128,10 +127,10 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
     if (!handshake.getProtocolVersion().isSupported()) {
       // Bump connection into correct protocol state so that we can send the disconnect packet.
       connection.setState(StateRegistry.LOGIN);
-      ic.disconnectQuietly(Component.translatable()
-              .key("multiplayer.disconnect.outdated_client")
-              .arguments(Argument.string("versions", ProtocolVersion.SUPPORTED_VERSION_STRING))
-              .build());
+      ic.disconnectQuietly(Component.translatable(
+          "multiplayer.disconnect.outdated_client",
+          Component.text(ProtocolVersion.SUPPORTED_VERSION_STRING)
+      ));
       return;
     }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialConnectSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialConnectSessionHandler.java
@@ -65,8 +65,7 @@ public class InitialConnectSessionHandler implements MinecraftSessionHandler {
       }
 
       byte[] copy = ByteBufUtil.getBytes(packet.content());
-      PluginMessageEvent event = new PluginMessageEvent(serverConn, serverConn.getPlayer(), id,
-          copy);
+      PluginMessageEvent event = new PluginMessageEvent(player, serverConn, id, copy);
       server.getEventManager().fire(event)
           .thenAcceptAsync(pme -> {
             if (pme.getResult().isAllowed() && serverConn.isActive()) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
@@ -268,14 +268,8 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
               inbound.disconnect(Component.translatable("multiplayer.disconnect.authservers_down"));
             }
           }, mcConnection.eventLoop())
-          .thenRun(() -> {
-            try {
-              httpClient.close();
-            } catch (Exception e) {
-              // In Java 21, the HttpClient does not throw any Exception
-              // when trying to clean its resources, so this should not happen
-              logger.error("An unknown error occurred while trying to close an HttpClient", e);
-            }
+          .whenComplete((ignored, throwable) -> {
+            httpClient.close();
           });
     } catch (GeneralSecurityException e) {
       logger.error("Unable to enable encryption", e);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
@@ -57,16 +57,16 @@ public class ServerListPingHandler {
     List<ServerPing.SamplePlayer> samplePlayers;
     if (configuration.getSamplePlayersInPing()) {
       List<ServerPing.SamplePlayer> unshuffledPlayers = server.getAllPlayers().stream()
-              .map(p -> {
-                if (p.getPlayerSettings().isClientListingAllowed()) {
-                  return new ServerPing.SamplePlayer(p.getUsername(), p.getUniqueId());
-                } else {
-                  return ServerPing.SamplePlayer.ANONYMOUS;
-                }
-              })
-              .collect(Collectors.toList());
+          .map(p -> {
+            if (p.getPlayerSettings().isClientListingAllowed()) {
+              return new ServerPing.SamplePlayer(p.getUsername(), p.getUniqueId());
+            } else {
+              return ServerPing.SamplePlayer.ANONYMOUS;
+            }
+          })
+          .collect(Collectors.toList());
       Collections.shuffle(unshuffledPlayers);
-      samplePlayers = unshuffledPlayers.subList(0, Math.min(12, server.getPlayerCount()));
+      samplePlayers = unshuffledPlayers.subList(0, Math.min(12, unshuffledPlayers.size()));
     } else {
       samplePlayers = ImmutableList.of();
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/ServerChannelInitializer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/ServerChannelInitializer.java
@@ -26,8 +26,10 @@ import static com.velocitypowered.proxy.network.Connections.MINECRAFT_ENCODER;
 import static com.velocitypowered.proxy.network.Connections.READ_TIMEOUT;
 
 import com.velocitypowered.proxy.VelocityServer;
+import com.velocitypowered.proxy.config.VelocityConfiguration;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.client.HandshakeSessionHandler;
+import com.velocitypowered.proxy.network.limiter.SimpleBytesPerSecondLimiter;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.netty.LegacyPingDecoder;
@@ -72,6 +74,17 @@ public class ServerChannelInitializer extends ChannelInitializer<Channel> {
         new HandshakeSessionHandler(connection, this.server));
     ch.pipeline().addLast(Connections.HANDLER, connection);
 
+    VelocityConfiguration.PacketLimiterConfig packetLimiterConfig =
+        server.getConfiguration().getPacketLimiterConfig();
+    int configuredInterval = packetLimiterConfig.interval();
+    int configuredPacketsPerSecond = packetLimiterConfig.pps();
+    int configuredBytes = packetLimiterConfig.bytes();
+
+    if (configuredInterval > 0 && (configuredBytes > 0 ||  configuredPacketsPerSecond > 0)) {
+      ch.pipeline().get(MinecraftVarintFrameDecoder.class).setPacketLimiter(
+          new SimpleBytesPerSecondLimiter(configuredPacketsPerSecond, configuredBytes, configuredInterval)
+      );
+    }
     if (this.server.getConfiguration().isProxyProtocol()) {
       ch.pipeline().addFirst(new HAProxyMessageDecoder());
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/ServerChannelInitializer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/ServerChannelInitializer.java
@@ -80,7 +80,7 @@ public class ServerChannelInitializer extends ChannelInitializer<Channel> {
     int configuredPacketsPerSecond = packetLimiterConfig.pps();
     int configuredBytes = packetLimiterConfig.bytes();
 
-    if (configuredInterval > 0 && (configuredBytes > 0 ||  configuredPacketsPerSecond > 0)) {
+    if (configuredInterval > 0 && (configuredBytes > 0 || configuredPacketsPerSecond > 0)) {
       ch.pipeline().get(MinecraftVarintFrameDecoder.class).setPacketLimiter(
           new SimpleBytesPerSecondLimiter(configuredPacketsPerSecond, configuredBytes, configuredInterval)
       );

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/limiter/PacketLimiter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/limiter/PacketLimiter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.network.limiter;
+
+/**
+ * PacketLimiter enforces a limit on the number of bytes processed over a time window.
+ * Implementations should be thread-safe.
+ */
+public interface PacketLimiter {
+  /**
+   * Attempts to record the specified number of bytes within the current window.
+   *
+   * @param bytes the number of bytes to record
+   * @return true if the bytes are allowed and recorded; false if the limit would be exceeded
+   */
+  boolean account(int bytes);
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/limiter/SimpleBytesPerSecondLimiter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/limiter/SimpleBytesPerSecondLimiter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.network.limiter;
+
+import com.velocitypowered.proxy.util.IntervalledCounter;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A moving-window limiter over a configurable number of seconds.
+ * It enforces both packets-per-second and average bytes-per-second limits.
+ * The effective cap over the full window equals limitPerSecond * windowSeconds.
+ */
+public final class SimpleBytesPerSecondLimiter implements PacketLimiter {
+  @Nullable
+  private final IntervalledCounter bytesCounter;
+  @Nullable
+  private final IntervalledCounter packetsCounter;
+  private final int packetsPerSecond;
+  private final int bytesPerSecond;
+
+  /**
+   * Creates a new SimpleBytesPerSecondLimiter.
+   *
+   * @param packetsPerSecond maximum average packets per second allowed (> 0)
+   * @param bytesPerSecond maximum average bytes per second allowed (> 0)
+   * @param windowSeconds number of seconds in the moving window (> 0)
+   */
+  public SimpleBytesPerSecondLimiter(int packetsPerSecond, int bytesPerSecond, int windowSeconds) {
+    this.packetsPerSecond = packetsPerSecond;
+    if (windowSeconds <= 0) {
+      throw new IllegalArgumentException("windowSeconds must be > 0");
+    }
+    this.bytesPerSecond = bytesPerSecond;
+    this.packetsCounter = packetsPerSecond > 0 ? new IntervalledCounter((long) (windowSeconds * 1.0e9)) : null;
+    this.bytesCounter = bytesPerSecond > 0 ? new IntervalledCounter((long) (windowSeconds * 1.0e9)) : null;
+
+  }
+
+  /**
+   * Records the given payload length as one packet and returns whether it is allowed.
+   */
+  @SuppressWarnings("RedundantIfStatement")
+  @Override
+  public boolean account(int bytes) {
+    long currTime = System.nanoTime();
+    if (packetsCounter != null) {
+      packetsCounter.updateAndAdd(1, currTime);
+      if (packetsCounter.getRate() > packetsPerSecond) {
+        return false;
+      }
+    }
+
+    if (bytesCounter != null) {
+      bytesCounter.updateAndAdd(bytes, currTime);
+      if (bytesCounter.getRate() > bytesPerSecond) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
@@ -97,6 +97,8 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
     ByteBuf uncompressed = preferredBuffer(ctx.alloc(), compressor, claimedUncompressedSize);
     try {
       compressor.inflate(compatibleIn, uncompressed, claimedUncompressedSize);
+      checkFrame(uncompressed.writerIndex() == claimedUncompressedSize,
+              "Decompressed size %s does not match claimed uncompressed size %s", uncompressed.writerIndex(), claimedUncompressedSize);
       out.add(uncompressed);
     } catch (Exception e) {
       uncompressed.release();

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
@@ -33,20 +33,26 @@ import java.util.List;
  */
 public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
 
+  private static final int SERVERBOUND_MAXIMUM_UNCOMPRESSED_SIZE = 2 * 1024 * 1024; // 2MiB
   private static final int VANILLA_MAXIMUM_UNCOMPRESSED_SIZE = 8 * 1024 * 1024; // 8MiB
   private static final int HARD_MAXIMUM_UNCOMPRESSED_SIZE = 128 * 1024 * 1024; // 128MiB
 
-  private static final int UNCOMPRESSED_CAP =
+  private static final int CLIENTBOUND_UNCOMPRESSED_CAP =
       Boolean.getBoolean("velocity.increased-compression-cap")
           ? HARD_MAXIMUM_UNCOMPRESSED_SIZE : VANILLA_MAXIMUM_UNCOMPRESSED_SIZE;
+  private static final int SERVERBOUND_UNCOMPRESSED_CAP =
+          Boolean.getBoolean("velocity.increased-compression-cap")
+                  ? HARD_MAXIMUM_UNCOMPRESSED_SIZE : SERVERBOUND_MAXIMUM_UNCOMPRESSED_SIZE;
   private static final boolean SKIP_COMPRESSION_VALIDATION = Boolean.getBoolean("velocity.skip-uncompressed-packet-size-validation");
+  private final ProtocolUtils.Direction direction;
 
   private int threshold;
   private final VelocityCompressor compressor;
 
-  public MinecraftCompressDecoder(int threshold, VelocityCompressor compressor) {
+  public MinecraftCompressDecoder(int threshold, VelocityCompressor compressor, ProtocolUtils.Direction direction) {
     this.threshold = threshold;
     this.compressor = compressor;
+    this.direction = direction;
   }
 
   @Override
@@ -65,10 +71,15 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
 
     checkFrame(claimedUncompressedSize >= threshold, "Uncompressed size %s is less than"
         + " threshold %s", claimedUncompressedSize, threshold);
-    checkFrame(claimedUncompressedSize <= UNCOMPRESSED_CAP,
-        "Uncompressed size %s exceeds hard threshold of %s", claimedUncompressedSize,
-        UNCOMPRESSED_CAP);
-
+    if (direction == ProtocolUtils.Direction.CLIENTBOUND) {
+      checkFrame(claimedUncompressedSize <= CLIENTBOUND_UNCOMPRESSED_CAP,
+              "Uncompressed size %s exceeds hard threshold of %s", claimedUncompressedSize,
+              CLIENTBOUND_UNCOMPRESSED_CAP);
+    } else {
+      checkFrame(claimedUncompressedSize <= SERVERBOUND_UNCOMPRESSED_CAP,
+              "Uncompressed size %s exceeds hard threshold of %s", claimedUncompressedSize,
+              SERVERBOUND_UNCOMPRESSED_CAP);
+    }
     ByteBuf compatibleIn = ensureCompatible(ctx.alloc(), compressor, in);
     ByteBuf uncompressed = preferredBuffer(ctx.alloc(), compressor, claimedUncompressedSize);
     try {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
@@ -44,6 +44,7 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
           Boolean.getBoolean("velocity.increased-compression-cap")
                   ? HARD_MAXIMUM_UNCOMPRESSED_SIZE : SERVERBOUND_MAXIMUM_UNCOMPRESSED_SIZE;
   private static final boolean SKIP_COMPRESSION_VALIDATION = Boolean.getBoolean("velocity.skip-uncompressed-packet-size-validation");
+  private static final double MAX_COMPRESSION_RATIO = Double.parseDouble(System.getProperty("velocity.max-compression-ratio", "10"));
   private final ProtocolUtils.Direction direction;
 
   private int threshold;
@@ -68,6 +69,7 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
       out.add(in.retain());
       return;
     }
+    int length = in.readableBytes();
 
     checkFrame(claimedUncompressedSize >= threshold, "Uncompressed size %s is less than"
         + " threshold %s", claimedUncompressedSize, threshold);
@@ -79,6 +81,10 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
       checkFrame(claimedUncompressedSize <= SERVERBOUND_UNCOMPRESSED_CAP,
               "Uncompressed size %s exceeds hard threshold of %s", claimedUncompressedSize,
               SERVERBOUND_UNCOMPRESSED_CAP);
+      double maxCompressedAllowed = length * MAX_COMPRESSION_RATIO;
+      checkFrame(claimedUncompressedSize <= maxCompressedAllowed,
+              "Uncompressed size %s exceeds ratio threshold of %s for compressed sized %s", claimedUncompressedSize,
+              maxCompressedAllowed, length);
     }
     ByteBuf compatibleIn = ensureCompatible(ctx.alloc(), compressor, in);
     ByteBuf uncompressed = preferredBuffer(ctx.alloc(), compressor, claimedUncompressedSize);

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
@@ -50,6 +50,13 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
   private int threshold;
   private final VelocityCompressor compressor;
 
+  /**
+   * Creates a new {@code MinecraftCompressDecoder} with the specified compression {@code threshold}.
+   *
+   * @param threshold the threshold for compression. Packets with uncompressed size below this threshold will not be compressed.
+   * @param compressor the compressor instance to use
+   * @param direction the direction of the packets being decoded
+   */
   public MinecraftCompressDecoder(int threshold, VelocityCompressor compressor, ProtocolUtils.Direction direction) {
     this.threshold = threshold;
     this.compressor = compressor;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
@@ -44,7 +44,7 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
           Boolean.getBoolean("velocity.increased-compression-cap")
                   ? HARD_MAXIMUM_UNCOMPRESSED_SIZE : SERVERBOUND_MAXIMUM_UNCOMPRESSED_SIZE;
   private static final boolean SKIP_COMPRESSION_VALIDATION = Boolean.getBoolean("velocity.skip-uncompressed-packet-size-validation");
-  private static final double MAX_COMPRESSION_RATIO = Double.parseDouble(System.getProperty("velocity.max-compression-ratio", "10"));
+  private static final double MAX_COMPRESSION_RATIO = Double.parseDouble(System.getProperty("velocity.max-compression-ratio", "64"));
   private final ProtocolUtils.Direction direction;
 
   private int threshold;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
@@ -22,11 +22,14 @@ import static com.velocitypowered.natives.util.MoreByteBufUtils.preferredBuffer;
 import static com.velocitypowered.proxy.protocol.util.NettyPreconditions.checkFrame;
 
 import com.velocitypowered.natives.compression.VelocityCompressor;
+import com.velocitypowered.proxy.network.limiter.PacketLimiter;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
+import com.velocitypowered.proxy.util.except.QuietDecoderException;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Decompresses a Minecraft packet.
@@ -44,11 +47,12 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
           Boolean.getBoolean("velocity.increased-compression-cap")
                   ? HARD_MAXIMUM_UNCOMPRESSED_SIZE : SERVERBOUND_MAXIMUM_UNCOMPRESSED_SIZE;
   private static final boolean SKIP_COMPRESSION_VALIDATION = Boolean.getBoolean("velocity.skip-uncompressed-packet-size-validation");
-  private static final double MAX_COMPRESSION_RATIO = Double.parseDouble(System.getProperty("velocity.max-compression-ratio", "64"));
   private final ProtocolUtils.Direction direction;
 
   private int threshold;
   private final VelocityCompressor compressor;
+  @Nullable
+  private PacketLimiter packetLimiter;
 
   /**
    * Creates a new {@code MinecraftCompressDecoder} with the specified compression {@code threshold}.
@@ -73,10 +77,13 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
             + " threshold %s", actualUncompressedSize, threshold);
       }
       // This message is not compressed.
+      if (packetLimiter != null && !packetLimiter.account(in.readableBytes())) {
+        throw new QuietDecoderException("Rate limit exceeded while processing packets for %s"
+            .formatted(ctx.channel().remoteAddress()));
+      }
       out.add(in.retain());
       return;
     }
-    int length = in.readableBytes();
 
     checkFrame(claimedUncompressedSize >= threshold, "Uncompressed size %s is less than"
         + " threshold %s", claimedUncompressedSize, threshold);
@@ -88,10 +95,6 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
       checkFrame(claimedUncompressedSize <= SERVERBOUND_UNCOMPRESSED_CAP,
               "Uncompressed size %s exceeds hard threshold of %s", claimedUncompressedSize,
               SERVERBOUND_UNCOMPRESSED_CAP);
-      double maxCompressedAllowed = length * MAX_COMPRESSION_RATIO;
-      checkFrame(claimedUncompressedSize <= maxCompressedAllowed,
-              "Uncompressed size %s exceeds ratio threshold of %s for compressed sized %s", claimedUncompressedSize,
-              maxCompressedAllowed, length);
     }
     ByteBuf compatibleIn = ensureCompatible(ctx.alloc(), compressor, in);
     ByteBuf uncompressed = preferredBuffer(ctx.alloc(), compressor, claimedUncompressedSize);
@@ -99,6 +102,10 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
       compressor.inflate(compatibleIn, uncompressed, claimedUncompressedSize);
       checkFrame(uncompressed.writerIndex() == claimedUncompressedSize,
               "Decompressed size %s does not match claimed uncompressed size %s", uncompressed.writerIndex(), claimedUncompressedSize);
+      if (packetLimiter != null && !packetLimiter.account(claimedUncompressedSize)) {
+        throw new QuietDecoderException("Rate limit exceeded while processing packets for %s"
+            .formatted(ctx.channel().remoteAddress()));
+      }
       out.add(uncompressed);
     } catch (Exception e) {
       uncompressed.release();
@@ -115,5 +122,9 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
 
   public void setThreshold(int threshold) {
     this.threshold = threshold;
+  }
+
+  public void setPacketLimiter(@Nullable PacketLimiter packetLimiter) {
+    this.packetLimiter = packetLimiter;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftDecoder.java
@@ -57,7 +57,11 @@ public class MinecraftDecoder extends ChannelInboundHandlerAdapter {
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
     if (msg instanceof ByteBuf buf) {
-      tryDecode(ctx, buf);
+      try {
+        tryDecode(ctx, buf);
+      } finally {
+        buf.release();
+      }
     } else {
       ctx.fireChannelRead(msg);
     }
@@ -65,7 +69,6 @@ public class MinecraftDecoder extends ChannelInboundHandlerAdapter {
 
   private void tryDecode(ChannelHandlerContext ctx, ByteBuf buf) throws Exception {
     if (!ctx.channel().isActive() || !buf.isReadable()) {
-      buf.release();
       return;
     }
 
@@ -75,27 +78,22 @@ public class MinecraftDecoder extends ChannelInboundHandlerAdapter {
     if (packet == null) {
       buf.readerIndex(originalReaderIndex);
       if (this.direction == ProtocolUtils.Direction.SERVERBOUND && this.state != StateRegistry.PLAY) {
-        buf.release();
         throw this.handleInvalidPacketId(packetId);
       }
-      ctx.fireChannelRead(buf);
+      ctx.fireChannelRead(buf.retain());
     } else {
+      doLengthSanityChecks(buf, packet);
+
       try {
-        doLengthSanityChecks(buf, packet);
-
-        try {
-          packet.decode(buf, direction, registry.version);
-        } catch (Exception e) {
-          throw handleDecodeFailure(e, packet, packetId);
-        }
-
-        if (buf.isReadable()) {
-          throw handleOverflow(packet, buf.readerIndex(), buf.writerIndex());
-        }
-        ctx.fireChannelRead(packet);
-      } finally {
-        buf.release();
+        packet.decode(buf, direction, registry.version);
+      } catch (Exception e) {
+        throw handleDecodeFailure(e, packet, packetId);
       }
+
+      if (buf.isReadable()) {
+        throw handleOverflow(packet, buf.readerIndex(), buf.writerIndex());
+      }
+      ctx.fireChannelRead(packet);
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftDecoder.java
@@ -104,7 +104,7 @@ public class MinecraftDecoder extends ChannelInboundHandlerAdapter {
       throw handleOverflow(packet, expectedMaxLen, buf.readableBytes());
     }
     if (buf.readableBytes() < expectedMinLen) {
-      throw handleUnderflow(packet, expectedMaxLen, buf.readableBytes());
+      throw handleUnderflow(packet, expectedMinLen, buf.readableBytes());
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftVarintFrameDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftVarintFrameDecoder.java
@@ -94,7 +94,6 @@ public class MinecraftVarintFrameDecoder extends ByteToMessageDecoder {
     in.readerIndex(packetStart);
 
     // try to read the length of the packet
-    in.markReaderIndex();
     try {
       int length = readRawVarInt21(in);
       if (packetStart == in.readerIndex()) {
@@ -107,6 +106,7 @@ public class MinecraftVarintFrameDecoder extends ByteToMessageDecoder {
       if (length > 0) {
         if (state == StateRegistry.HANDSHAKE && direction == ProtocolUtils.Direction.SERVERBOUND) {
           if (validateServerboundHandshakePacket(in, length)) {
+            in.readerIndex(packetStart);
             return;
           }
         }
@@ -115,7 +115,7 @@ public class MinecraftVarintFrameDecoder extends ByteToMessageDecoder {
       // note that zero-length packets are ignored
       if (length > 0) {
         if (in.readableBytes() < length) {
-          in.resetReaderIndex();
+          in.readerIndex(packetStart);
         } else {
           // If enabled, rate-limit serverbound payload bytes based on frame length
           if (packetLimiter != null) {
@@ -130,7 +130,7 @@ public class MinecraftVarintFrameDecoder extends ByteToMessageDecoder {
       }
     } catch (Exception e) {
       // Reset buffer to consistent state before propagating exception to prevent memory leaks
-      in.resetReaderIndex();
+      in.readerIndex(packetStart);
       throw e;
     }
   }
@@ -140,40 +140,33 @@ public class MinecraftVarintFrameDecoder extends ByteToMessageDecoder {
         state.getProtocolRegistry(direction, ProtocolVersion.MINIMUM_VERSION);
 
     final int index = in.readerIndex();
-    try {
-      final int packetId = readRawVarInt21(in);
-      // Index hasn't changed, we've read nothing
-      if (index == in.readerIndex()) {
-        in.resetReaderIndex();
-        return true;
-      }
-      final int payloadLength = length - ProtocolUtils.varIntBytes(packetId);
-
-      MinecraftPacket packet = registry.createPacket(packetId);
-
-      // We handle every packet in this phase, if you said something we don't know, something is really wrong
-      if (packet == null) {
-        throw UNKNOWN_PACKET;
-      }
-
-      // We 'technically' have the incoming bytes of a payload here, and so, these can actually parse
-      // the packet if needed, so, we'll take advantage of the existing methods
-      int expectedMinLen = packet.decodeExpectedMinLength(in, direction, registry.version);
-      int expectedMaxLen = packet.decodeExpectedMaxLength(in, direction, registry.version);
-      if (expectedMaxLen != -1 && payloadLength > expectedMaxLen) {
-        throw handleOverflow(packet, expectedMaxLen, in.readableBytes());
-      }
-      if (payloadLength < expectedMinLen) {
-        throw handleUnderflow(packet, expectedMaxLen, in.readableBytes());
-      }
-
-      in.readerIndex(index);
-      return false;
-    } catch (Exception e) {
-      // Reset buffer to consistent state before propagating exception to prevent memory leaks
-      in.readerIndex(index);
-      throw e;
+    final int packetId = readRawVarInt21(in);
+    // Index hasn't changed, we've read nothing
+    if (index == in.readerIndex()) {
+      return true;
     }
+    final int payloadLength = length - ProtocolUtils.varIntBytes(packetId);
+
+    MinecraftPacket packet = registry.createPacket(packetId);
+
+    // We handle every packet in this phase, if you said something we don't know, something is really wrong
+    if (packet == null) {
+      throw UNKNOWN_PACKET;
+    }
+
+    // We 'technically' have the incoming bytes of a payload here, and so, these can actually parse
+    // the packet if needed, so, we'll take advantage of the existing methods
+    int expectedMinLen = packet.decodeExpectedMinLength(in, direction, registry.version);
+    int expectedMaxLen = packet.decodeExpectedMaxLength(in, direction, registry.version);
+    if (expectedMaxLen != -1 && payloadLength > expectedMaxLen) {
+      throw handleOverflow(packet, expectedMaxLen, in.readableBytes());
+    }
+    if (payloadLength < expectedMinLen) {
+      throw handleUnderflow(packet, expectedMaxLen, in.readableBytes());
+    }
+
+    in.readerIndex(index);
+    return false;
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftVarintFrameDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftVarintFrameDecoder.java
@@ -20,6 +20,7 @@ package com.velocitypowered.proxy.protocol.netty;
 import static io.netty.util.ByteProcessor.FIND_NON_NUL;
 
 import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.proxy.network.limiter.PacketLimiter;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.StateRegistry;
@@ -32,6 +33,7 @@ import io.netty.handler.codec.CorruptedFrameException;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Frames Minecraft server packets which are prefixed by a 21-bit VarInt encoding.
@@ -54,6 +56,8 @@ public class MinecraftVarintFrameDecoder extends ByteToMessageDecoder {
   private final ProtocolUtils.Direction direction;
   private final StateRegistry.PacketRegistry.ProtocolRegistry registry;
   private StateRegistry state;
+  @Nullable
+  private PacketLimiter packetLimiter;
 
   /**
    * Creates a new {@code MinecraftVarintFrameDecoder} decoding packets from the specified {@code Direction}.
@@ -113,6 +117,14 @@ public class MinecraftVarintFrameDecoder extends ByteToMessageDecoder {
         if (in.readableBytes() < length) {
           in.resetReaderIndex();
         } else {
+          // If enabled, rate-limit serverbound payload bytes based on frame length
+          if (packetLimiter != null) {
+            if (!packetLimiter.account(length)) {
+              throw new QuietDecoderException(
+                      "Rate limit exceeded while processing packets for %s".formatted(
+                              ctx.channel().remoteAddress()));
+            }
+          }
           out.add(in.readRetainedSlice(length));
         }
       }
@@ -264,5 +276,9 @@ public class MinecraftVarintFrameDecoder extends ByteToMessageDecoder {
 
   public void setState(StateRegistry stateRegistry) {
     this.state = stateRegistry;
+  }
+
+  public void setPacketLimiter(@Nullable PacketLimiter packetLimiter) {
+    this.packetLimiter = packetLimiter;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftVarintFrameDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftVarintFrameDecoder.java
@@ -159,10 +159,10 @@ public class MinecraftVarintFrameDecoder extends ByteToMessageDecoder {
     int expectedMinLen = packet.decodeExpectedMinLength(in, direction, registry.version);
     int expectedMaxLen = packet.decodeExpectedMaxLength(in, direction, registry.version);
     if (expectedMaxLen != -1 && payloadLength > expectedMaxLen) {
-      throw handleOverflow(packet, expectedMaxLen, in.readableBytes());
+      throw handleOverflow(packet, expectedMaxLen, payloadLength);
     }
     if (payloadLength < expectedMinLen) {
-      throw handleUnderflow(packet, expectedMaxLen, in.readableBytes());
+      throw handleUnderflow(packet, expectedMinLen, payloadLength);
     }
 
     in.readerIndex(index);

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
@@ -52,6 +52,7 @@ public class JoinGamePacket implements MinecraftPacket {
   private @Nullable Pair<String, Long> lastDeathPosition; // 1.19+
   private int portalCooldown; // 1.20+
   private int seaLevel; // 1.21.2+
+  private boolean onlineMode; // 26.2+
   private boolean enforcesSecureChat; // 1.20.5+
 
   public int getEntityId() {
@@ -190,6 +191,10 @@ public class JoinGamePacket implements MinecraftPacket {
     this.seaLevel = seaLevel;
   }
 
+  public void setOnlineMode(boolean onlineMode) {
+    this.onlineMode = onlineMode;
+  }
+
   public boolean getEnforcesSecureChat() {
     return this.enforcesSecureChat;
   }
@@ -213,7 +218,7 @@ public class JoinGamePacket implements MinecraftPacket {
         dimensionInfo + '\'' + ", currentDimensionData='" + currentDimensionData + '\'' +
         ", previousGamemode=" + previousGamemode + ", simulationDistance=" + simulationDistance +
         ", lastDeathPosition='" + lastDeathPosition + '\'' + ", portalCooldown=" + portalCooldown +
-        ", seaLevel=" + seaLevel +
+        ", seaLevel=" + seaLevel + ", onlineMode=" + this.onlineMode +
         '}';
   }
 
@@ -356,6 +361,10 @@ public class JoinGamePacket implements MinecraftPacket {
 
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
       this.seaLevel = ProtocolUtils.readVarInt(buf);
+    }
+
+    if (version.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
+      this.onlineMode = buf.readBoolean();
     }
 
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_20_5)) {
@@ -508,6 +517,10 @@ public class JoinGamePacket implements MinecraftPacket {
 
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
       ProtocolUtils.writeVarInt(buf, seaLevel);
+    }
+
+    if (version.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
+      buf.writeBoolean(this.onlineMode);
     }
 
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_20_5)) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/PluginMessagePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/PluginMessagePacket.java
@@ -31,7 +31,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class PluginMessagePacket extends DeferredByteBufHolder implements MinecraftPacket {
 
-  private static final int MAX_PAYLOAD_SIZE = Integer.getInteger("velocity.max-plugin-message-payload-size", 32767);
+  private static final int MAX_PAYLOAD_SIZE_CLIENTBOUND = getPayloadLimit(Direction.CLIENTBOUND);
+  private static final int MAX_PAYLOAD_SIZE_SERVERBOUND = getPayloadLimit(Direction.SERVERBOUND);
 
   private @Nullable String channel;
 
@@ -50,6 +51,19 @@ public class PluginMessagePacket extends DeferredByteBufHolder implements Minecr
       throw new IllegalStateException("Channel is not specified.");
     }
     return channel;
+  }
+
+  private static int getPayloadLimit(Direction direction) {
+    if (System.getProperty("velocity.max-plugin-message-payload-size") != null) {
+      return Integer.getInteger("velocity.max-plugin-message-payload-size");
+    }
+    if (direction == Direction.SERVERBOUND) {
+      return Integer.getInteger("velocity.max-plugin-message-payload-size.serverbound", 32767);
+    } else {
+      // This is the vanilla expected limit, a payload this large feels like a nightmare given the trust
+      // we give to servers...
+      return Integer.getInteger("velocity.max-plugin-message-payload-size.clientbound", 1048576);
+    }
   }
 
   public void setChannel(String channel) {
@@ -104,7 +118,8 @@ public class PluginMessagePacket extends DeferredByteBufHolder implements Minecr
 
   @Override
   public int decodeExpectedMaxLength(ByteBuf buf, Direction direction, ProtocolVersion version) {
-    return ProtocolUtils.DEFAULT_MAX_STRING_BYTES + MAX_PAYLOAD_SIZE;
+    return ProtocolUtils.DEFAULT_MAX_STRING_BYTES +
+        (direction == Direction.CLIENTBOUND ? MAX_PAYLOAD_SIZE_CLIENTBOUND : MAX_PAYLOAD_SIZE_SERVERBOUND);
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ServerLoginSuccessPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ServerLoginSuccessPacket.java
@@ -35,6 +35,7 @@ public class ServerLoginSuccessPacket implements MinecraftPacket {
   private @Nullable UUID uuid;
   private @Nullable String username;
   private @Nullable List<GameProfile.Property> properties;
+  private @Nullable UUID sessionId;
   private static final boolean strictErrorHandling = VelocityProperties
           .readBoolean("velocity.strictErrorHandling", true);
 
@@ -68,6 +69,10 @@ public class ServerLoginSuccessPacket implements MinecraftPacket {
     this.properties = properties;
   }
 
+  public void setSessionId(@Nullable UUID sessionId) {
+    this.sessionId = sessionId;
+  }
+
   @Override
   public String toString() {
     return "ServerLoginSuccess{"
@@ -95,6 +100,10 @@ public class ServerLoginSuccessPacket implements MinecraftPacket {
     }
     if (version == ProtocolVersion.MINECRAFT_1_20_5 || version == ProtocolVersion.MINECRAFT_1_21) {
       buf.readBoolean();
+    }
+
+    if (version.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
+      this.sessionId = ProtocolUtils.readUuid(buf);
     }
   }
 
@@ -126,6 +135,10 @@ public class ServerLoginSuccessPacket implements MinecraftPacket {
     }
     if (version == ProtocolVersion.MINECRAFT_1_20_5 || version == ProtocolVersion.MINECRAFT_1_21) {
       buf.writeBoolean(strictErrorHandling);
+    }
+
+    if (version.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
+      ProtocolUtils.writeUuid(buf, this.sessionId);
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
@@ -24,6 +24,7 @@ import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_20_3;
 import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_20_5;
 import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_21_5;
 import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_21_6;
+import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_26_2;
 import static com.velocitypowered.proxy.protocol.packet.brigadier.ArgumentIdentifier.id;
 import static com.velocitypowered.proxy.protocol.packet.brigadier.ArgumentIdentifier.mapSet;
 import static com.velocitypowered.proxy.protocol.packet.brigadier.DoubleArgumentPropertySerializer.DOUBLE;
@@ -207,7 +208,7 @@ public class ArgumentPropertyRegistry {
     empty(id("minecraft:block_predicate", mapSet(MINECRAFT_1_19, 13)));
     empty(id("minecraft:item_stack", mapSet(MINECRAFT_1_19, 14)));
     empty(id("minecraft:item_predicate", mapSet(MINECRAFT_1_19, 15)));
-    empty(id("minecraft:color", mapSet(MINECRAFT_1_19, 16)));
+    empty(id("minecraft:color", mapSet(MINECRAFT_26_2, -1), mapSet(MINECRAFT_1_19, 16))); // renamed to team_color in 26.2
     empty(id("minecraft:component", mapSet(MINECRAFT_1_21_6, 18), mapSet(MINECRAFT_1_19, 17)));
     empty(id("minecraft:style", mapSet(MINECRAFT_1_21_6, 19), mapSet(MINECRAFT_1_20_3, 18))); // added 1.20.3
     empty(id("minecraft:message", mapSet(MINECRAFT_1_21_6, 20), mapSet(MINECRAFT_1_20_3, 19), mapSet(MINECRAFT_1_19, 18)));
@@ -281,6 +282,7 @@ public class ArgumentPropertyRegistry {
 
     empty(id("minecraft:hex_color", mapSet(MINECRAFT_1_21_6, 17))); // added in 1.21.6
     empty(id("minecraft:dialog", mapSet(MINECRAFT_1_21_6, 55))); // added in 1.21.6
+    empty(id("minecraft:team_color", mapSet(MINECRAFT_26_2, 16))); // renamed from color in 26.2
 
     // Crossstitch support
     register(id("crossstitch:mod_argument", mapSet(MINECRAFT_1_19, -256)), ModArgumentProperty.class, MOD);

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/IntervalledCounter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/IntervalledCounter.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2025 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.util;
+
+/**
+ * IntervalledCounter maintains a rolling sum of values associated with timestamps, keeping
+ * only those entries that fall within a fixed time interval from the most recent timestamp.
+ *
+ * <p>Time values must be provided in the same unit as {@link System#nanoTime()} (nanoseconds),
+ * and the configured interval is also expressed in nanoseconds. Callers are expected to
+ * periodically advance the counter to the current time using {@link #updateCurrentTime()} or
+ * {@link #updateCurrentTime(long)} to evict expired entries before adding new ones via
+ * {@link #addTime(long)} or {@link #addTime(long, long)}.</p>
+ *
+ * <p>This class is not thread-safe. If multiple threads access an instance concurrently,
+ * external synchronization is required.</p>
+ */
+@SuppressWarnings("checkstyle:WhitespaceAfter") // Not our class
+public final class IntervalledCounter {
+
+  private static final int INITIAL_SIZE = 8;
+
+  /**
+   * Ring buffer holding the timestamp (in nanoseconds) for each data point.
+   */
+  protected long[] times;
+  /**
+   * Ring buffer holding the count associated with each timestamp.
+   */
+  protected long[] counts;
+  /**
+   * The sliding window size in nanoseconds. Only entries with time >= (currentTime - interval)
+   * are considered part of the window.
+   */
+  protected final long interval;
+  /**
+   * Cached lower bound of the window (in nanoseconds) after the last update.
+   */
+  protected long minTime;
+  /**
+   * Running sum of all counts currently within the window.
+   */
+  protected long sum;
+  /**
+   * Head index (inclusive) of the ring buffer.
+   */
+  protected int head; // inclusive
+  /**
+   * Tail index (exclusive) of the ring buffer.
+   */
+  protected int tail; // exclusive
+
+  /**
+   * Creates a new counter with the specified interval.
+   *
+   * @param interval the window size in nanoseconds (compatible with {@link System#nanoTime()})
+   */
+  public IntervalledCounter(final long interval) {
+    this.times = new long[INITIAL_SIZE];
+    this.counts = new long[INITIAL_SIZE];
+    this.interval = interval;
+  }
+
+  /**
+   * Advances the window to the current time using {@link System#nanoTime()}, evicting any
+   * data points that have fallen outside of the interval and updating the running sum.
+   */
+  public void updateCurrentTime() {
+    this.updateCurrentTime(System.nanoTime());
+  }
+
+  /**
+   * Advances the window to the provided time, evicting any data points older than
+   * {@code currentTime - interval} and updating the running sum.
+   *
+   * @param currentTime the current time in nanoseconds (as from {@link System#nanoTime()})
+   */
+  public void updateCurrentTime(final long currentTime) {
+    long sum = this.sum;
+    int head = this.head;
+    final int tail = this.tail;
+    final long minTime = currentTime - this.interval;
+
+    final int arrayLen = this.times.length;
+
+    // guard against overflow by using subtraction
+    while (head != tail && this.times[head] - minTime < 0) {
+      sum -= this.counts[head];
+      // there are two ways we can do this:
+      // 1. free the count when adding
+      // 2. free it now
+      // option #2
+      this.counts[head] = 0;
+      if (++head >= arrayLen) {
+        head = 0;
+      }
+    }
+
+    this.sum = sum;
+    this.head = head;
+    this.minTime = minTime;
+  }
+
+  /**
+   * Adds a single unit at the specified timestamp, assuming the timestamp is within the current
+   * window. If the timestamp is older than the current window lower bound, the value is ignored.
+   * This method does not automatically advance the window; callers should invoke
+   * {@link #updateCurrentTime()} or {@link #updateCurrentTime(long)} beforehand.
+   *
+   * @param currTime the timestamp in nanoseconds
+   */
+  public void addTime(final long currTime) {
+    this.addTime(currTime, 1L);
+  }
+
+  /**
+   * Adds {@code count} units at the specified timestamp, assuming the timestamp is within the
+   * current window. If the timestamp is older than {@code minTime}, the value is ignored.
+   * This method does not automatically advance the window; callers should invoke
+   * {@link #updateCurrentTime()} or {@link #updateCurrentTime(long)} beforehand.
+   *
+   * @param currTime the timestamp in nanoseconds
+   * @param count the amount to add (non-negative)
+   */
+  public void addTime(final long currTime, final long count) {
+    // guard against overflow by using subtraction
+    if (currTime - this.minTime < 0) {
+      return;
+    }
+    int nextTail = (this.tail + 1) % this.times.length;
+    if (nextTail == this.head) {
+      this.resize();
+      nextTail = (this.tail + 1) % this.times.length;
+    }
+
+    this.times[this.tail] = currTime;
+    this.counts[this.tail] += count;
+    this.sum += count;
+    this.tail = nextTail;
+  }
+
+  /**
+   * Convenience method that advances the window to the current time and then adds {@code count}
+   * units at that time.
+   *
+   * @param count the amount to add (non-negative)
+   */
+  public void updateAndAdd(final long count) {
+    final long currTime = System.nanoTime();
+    this.updateCurrentTime(currTime);
+    this.addTime(currTime, count);
+  }
+
+  /**
+   * Convenience method that advances the window to {@code currTime} and then adds {@code count}
+   * units at that time.
+   *
+   * @param count the amount to add (non-negative)
+   * @param currTime the timestamp in nanoseconds
+   */
+  public void updateAndAdd(final long count, final long currTime) {
+    this.updateCurrentTime(currTime);
+    this.addTime(currTime, count);
+  }
+
+  /**
+   * Doubles the capacity of the internal ring buffers, preserving the order of existing data.
+   */
+  private void resize() {
+    final long[] oldElements = this.times;
+    final long[] oldCounts = this.counts;
+    final long[] newElements = new long[this.times.length * 2];
+    final long[] newCounts = new long[this.times.length * 2];
+    this.times = newElements;
+    this.counts = newCounts;
+
+    final int head = this.head;
+    final int tail = this.tail;
+    final int size = tail >= head ? (tail - head) : (tail + (oldElements.length - head));
+    this.head = 0;
+    this.tail = size;
+
+    if (tail >= head) {
+      // sequentially ordered from [head, tail)
+      System.arraycopy(oldElements, head, newElements, 0, size);
+      System.arraycopy(oldCounts, head, newCounts, 0, size);
+    } else {
+      // ordered from [head, length)
+      // then followed by [0, tail)
+
+      System.arraycopy(oldElements, head, newElements, 0, oldElements.length - head);
+      System.arraycopy(oldElements, 0, newElements, oldElements.length - head, tail);
+
+      System.arraycopy(oldCounts, head, newCounts, 0, oldCounts.length - head);
+      System.arraycopy(oldCounts, 0, newCounts, oldCounts.length - head, tail);
+    }
+  }
+
+  /**
+   * Returns the current rate in units per second based on the rolling sum and the configured
+   * interval. Specifically: {@code sum / (intervalSeconds)} where {@code intervalSeconds}
+   * equals {@code interval / 1e9}.
+   *
+   * @return the rate in units per second for the current window
+   */
+  public double getRate() {
+    return (double)this.sum / ((double)this.interval * 1.0E-9);
+  }
+
+  /**
+   * Returns the configured interval size in nanoseconds.
+   *
+   * @return the interval size in nanoseconds
+   */
+  public long getInterval() {
+    return this.interval;
+  }
+
+  /**
+   * Returns the rolling sum of all counts currently within the window.
+   *
+   * @return the rolling sum
+   */
+  public long getSum() {
+    return this.sum;
+  }
+
+  /**
+   * Returns the number of data points currently stored in the internal ring buffer. This may be
+   * less than or equal to the number of points added since older entries may have been evicted.
+   *
+   * @return the number of stored data points
+   */
+  public int totalDataPoints() {
+    return this.tail >= this.head ? (this.tail - this.head) : (this.tail + (this.counts.length - this.head));
+  }
+}

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
@@ -25,6 +25,7 @@ velocity.error.internal-server-connection-error=An internal server connection er
 velocity.error.logging-in-too-fast=You are logging in too fast, try again later.
 velocity.error.online-mode-only=You are not logged into your Minecraft account. If you are logged into your Minecraft account, try restarting your Minecraft client.
 velocity.error.player-connection-error=An internal error occurred in your connection.
+velocity.error.plugin-message-overflow=You sent too many plugin messages before completing the connection.
 velocity.error.modern-forwarding-needs-new-client=This server is only compatible with Minecraft 1.13 and above.
 velocity.error.modern-forwarding-failed=Your server did not send a forwarding request to the proxy. Make sure the server is configured for Velocity forwarding.
 velocity.error.moved-to-new-server=You were kicked from <arg:0>: <arg:1>

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -74,6 +74,11 @@ sample-players-in-ping = false
 # If not enabled (default is true) player IP addresses will be replaced by <ip address withheld> in logs
 enable-player-address-logging = true
 
+[packet-limiter]
+interval = 7
+packets-per-second = 500
+bytes-per-second = -1
+
 [servers]
 # Configure your servers here. Each key represents the server's name, and the value
 # represents the IP address of the server to connect to.

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -1,5 +1,5 @@
 # Config version. Do not change this
-config-version = "2.7"
+config-version = "2.8"
 
 # What port should the proxy be bound to? By default, we'll bind to all addresses on port 25565.
 bind = "0.0.0.0:25565"
@@ -75,9 +75,17 @@ sample-players-in-ping = false
 enable-player-address-logging = true
 
 [packet-limiter]
+# Size of the moving time window in seconds used to calculate average rates.
+# A larger window tolerates short bursts while still enforcing the configured limits over time.
 interval = 7
-packets-per-second = 500
+# Maximum average number of packets per second a client may send. -1 disables this check.
+packets-per-second = -1
+# Maximum average number of compressed (on-wire) bytes per second a client may send. -1 disables this check.
 bytes-per-second = -1
+# Maximum average number of decompressed bytes per second a client may send.
+# Protects against compression bomb attacks where small packets expand to excessive sizes after decompression.
+# -1 disables this check.
+decompressed-bytes-per-second = 5242880
 
 [servers]
 # Configure your servers here. Each key represents the server's name, and the value


### PR DESCRIPTION
## Summary
- Merges `PaperMC/Velocity` `dev/3.0.0` into this fork's `dev/3.0.0`.
- Resolves conflicts in `ProtocolVersion` by taking upstream Minecraft 26.1.2/26.2 protocol updates.
- Resolves `ClientPlaySessionHandler` by preserving upstream functional changes; the fork-side difference there was whitespace-only.
- Formats the fork's `LoginEvent` addition to satisfy current Checkstyle while preserving the server ID hash API.

## Verification
- `./gradlew build --no-daemon --stacktrace` ✅
